### PR TITLE
frontend: also support vertical in fullscreen mode

### DIFF
--- a/frontends/web/src/components/alert/Alert.tsx
+++ b/frontends/web/src/components/alert/Alert.tsx
@@ -65,8 +65,9 @@ const Alert = () => {
       <View
         key="alert-overlay"
         dialog={asDialog}
+        fullscreen
         textCenter={!asDialog}
-        fullscreen>
+        verticallyCentered>
         <ViewHeader title={<MultilineMarkup tagName="span" markup={message} />} />
         <ViewButtons>
           <Button

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -103,7 +103,11 @@ class Aopp extends Component<Props, State> {
     switch (aopp.state) {
     case 'error':
       return (
-        <View fullscreen textCenter>
+        <View
+          fullscreen
+          textCenter
+          verticallyCentered
+          width="580px">
           <ViewHeader title={t('aopp.errorTitle')}>
             <p>{domain(aopp.callback)}</p>
           </ViewHeader>
@@ -123,7 +127,11 @@ class Aopp extends Component<Props, State> {
       return null;
     case 'user-approval':
       return (
-        <View fullscreen textCenter>
+        <View
+          fullscreen
+          textCenter
+          verticallyCentered
+          width="580px">
           <ViewHeader title={t('aopp.title')} withAppLogo />
           <ViewContent>
             <Vasp prominent
@@ -154,7 +162,11 @@ class Aopp extends Component<Props, State> {
       });
       return (
         <form onSubmit={this.chooseAccount}>
-          <View fullscreen textCenter>
+          <View
+            fullscreen
+            textCenter
+            verticallyCentered
+            width="580px">
             <ViewHeader title={t('aopp.title')}>
               <Vasp hostname={domain(aopp.callback)} />
             </ViewHeader>
@@ -176,7 +188,11 @@ class Aopp extends Component<Props, State> {
     }
     case 'syncing':
       return (
-        <View fullscreen textCenter>
+        <View
+          fullscreen
+          textCenter
+          verticallyCentered
+          width="580px">
           <ViewHeader title={t('aopp.title')}>
             <Vasp hostname={domain(aopp.callback)} />
           </ViewHeader>
@@ -190,7 +206,11 @@ class Aopp extends Component<Props, State> {
       );
     case 'signing':
       return (
-        <View fullscreen textCenter>
+        <View
+          fullscreen
+          textCenter
+          verticallyCentered
+          width="580px">
           <ViewHeader small title={t('aopp.title')}>
             <Vasp hostname={domain(aopp.callback)} />
           </ViewHeader>
@@ -212,7 +232,12 @@ class Aopp extends Component<Props, State> {
       );
     case 'success':
       return (
-        <View fitContent fullscreen textCenter>
+        <View
+          fitContent
+          fullscreen
+          textCenter
+          verticallyCentered
+          width="580px">
           <ViewContent withIcon="success">
             <p className={styles.successText}>{t('aopp.success.title')}</p>
             <p className={styles.proceed}>

--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -38,15 +38,14 @@
 .inner {
     display: flex;
     flex-direction: column;
-    margin: auto;
-    max-width: 100%;
-    padding-bottom: var(--space-half);
-    padding-top: var(--space-half);
-    width: 480px;
-}
-.fill:not(.verticallyCentered) .inner {
-    margin: 0;
+    margin: 0 auto;
+    max-width: var(--content-width);
+    padding: var(--space-half) 0;
     width: 100%;
+}
+.verticallyCentered .inner {
+    margin-bottom: auto;
+    margin-top: auto;
 }
 .inner.fit {
     flex-shrink: 0;
@@ -79,15 +78,31 @@
         padding-top: 2vh;
     }
 }
+@media (min-width: 769px) {
+    .fullscreen .inner {
+        padding-left: var(--space-default);
+        padding-right: var(--space-default);
+    }
+}
+@media (max-width: 1080px) {
+    .inner {
+        max-width: 100%;
+    }
+}
 @media (min-width: 1200px) {
     .inner {
-        width: 580px;
+        padding-left: 0;
+        padding-right: 0;
     }
 }
 .dialog .inner {
     background-color: var(--background-secondary);
     box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.3);
     flex-grow: 0;
+    max-width: 100%;
+    padding-left: 0;
+    padding-right: 0;
+    width: 540px;
 }
 
 .header {

--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -44,7 +44,7 @@
     padding-top: var(--space-half);
     width: 480px;
 }
-.fill .inner {
+.fill:not(.verticallyCentered) .inner {
     margin: 0;
     width: 100%;
 }

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -29,6 +29,7 @@ type TViewProps = {
     minHeight?: string;
     onClose?: () => void;
     textCenter?: boolean;
+    verticallyCentered?: boolean;
     width?: string;
     withBottomBar?: boolean;
 };
@@ -41,6 +42,7 @@ type TViewProps = {
  * @param minHeight optional minimum height, useful for keeping content area same size through multiple views
  * @param onClose if a callback is provided it will render a close button that triggers the callback
  * @param textCenter centers all text content in the view
+ * @param verticallyCentered centers all text content in the view
  * @param width can be used to overwrite the default width of the inner area
  * @param withBottomBar enables a footer with some logo and language switch
  */
@@ -52,11 +54,14 @@ export const View = ({
   minHeight,
   onClose,
   textCenter,
+  verticallyCentered = false,
   width,
   withBottomBar,
 }: TViewProps) => {
   const containerClasses = `${
     style[fullscreen ? 'fullscreen' : 'fill']
+  } ${
+    style[verticallyCentered ? 'verticallyCentered' : '']
   } ${
     dialog ? style.dialog : ''
   }`;

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -42,7 +42,7 @@ type TViewProps = {
  * @param minHeight optional minimum height, useful for keeping content area same size through multiple views
  * @param onClose if a callback is provided it will render a close button that triggers the callback
  * @param textCenter centers all text content in the view
- * @param verticallyCentered centers all text content in the view
+ * @param verticallyCentered centers all text content in the view, has no effect in dialog mode
  * @param width can be used to overwrite the default width of the inner area
  * @param withBottomBar enables a footer with some logo and language switch
  */
@@ -61,7 +61,7 @@ export const View = ({
   const containerClasses = `${
     style[fullscreen ? 'fullscreen' : 'fill']
   } ${
-    style[verticallyCentered ? 'verticallyCentered' : '']
+    verticallyCentered ? style.verticallyCentered : ''
   } ${
     dialog ? style.dialog : ''
   }`;

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -456,6 +456,7 @@ class BitBox02 extends Component<Props, State> {
         <View
           key="wait-view"
           fullscreen
+          verticallyCentered
           textCenter>
           <ViewHeader title={waitDialog.title}>
             <p>{waitDialog.text ? waitDialog.text : t('bitbox02Interact.followInstructions')}</p>
@@ -475,13 +476,14 @@ class BitBox02 extends Component<Props, State> {
             key="connection"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
-            width="600px">
+            width="690px">
             <ViewHeader title={t('button.unlock')}>
               <p>{t('bitbox02Wizard.stepConnected.unlock')}</p>
             </ViewHeader>
             <ViewContent fullWidth>
-              {attestationResult === false ? (
+              {attestationResult === true ? (
                 <Status>
                   {t('bitbox02Wizard.attestationFailed')}
                 </Status>
@@ -497,6 +499,7 @@ class BitBox02 extends Component<Props, State> {
             key="pairing"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="670px">
             <ViewHeader title={t('bitbox02Wizard.pairing.title')}>
@@ -539,6 +542,7 @@ class BitBox02 extends Component<Props, State> {
             key="uninitialized-pairing"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="950px">
             <ViewHeader title={t('bitbox02Wizard.stepUninitialized.title')}>
@@ -590,6 +594,7 @@ class BitBox02 extends Component<Props, State> {
               fullscreen
               textCenter
               withBottomBar
+              verticallyCentered
               width="600px">
               <ViewHeader title={t('bitbox02Wizard.stepCreate.title')}>
                 {!sdCardInserted && (
@@ -633,6 +638,7 @@ class BitBox02 extends Component<Props, State> {
             key="create-wallet"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="600px">
             <ViewHeader title={t('bitbox02Wizard.stepPassword.title')}>
@@ -655,6 +661,7 @@ class BitBox02 extends Component<Props, State> {
               key="create-backup"
               fullscreen
               textCenter
+              verticallyCentered
               withBottomBar
               width="700px">
               <ViewHeader title={t('backup.create.title')}>
@@ -710,6 +717,7 @@ class BitBox02 extends Component<Props, State> {
             key="restore"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="700px">
             <ViewHeader title={t('backup.restore.confirmTitle')}>
@@ -737,6 +745,7 @@ class BitBox02 extends Component<Props, State> {
             key="set-password"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="700px">
             <ViewHeader title={t('backup.restore.confirmTitle')}>
@@ -771,6 +780,7 @@ class BitBox02 extends Component<Props, State> {
             fitContent
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar>
             <ViewHeader title={t('bitbox02Wizard.success.title')}>
               <p>{t('bitbox02Wizard.stepCreateSuccess.success')}</p>
@@ -791,6 +801,7 @@ class BitBox02 extends Component<Props, State> {
             key="backup-success"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="700px">
             <ViewHeader title={t('bitbox02Wizard.stepBackupSuccess.title')} />
@@ -818,6 +829,7 @@ class BitBox02 extends Component<Props, State> {
             key="backup-mnemonic-success"
             fullscreen
             textCenter
+            verticallyCentered
             withBottomBar
             width="700px">
             <ViewHeader title={t('bitbox02Wizard.stepBackupSuccess.title')} />

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -34,7 +34,6 @@ const INFO_STEPS_ENABLE = 5;
 const INFO_STEPS_DISABLE = 0;
 
 const CONTENT_MIN_HEIGHT = '38em';
-const CONTENT_WIDTH = '740px';
 
 interface MnemonicPassphraseButtonProps {
     deviceID: string;
@@ -129,7 +128,7 @@ class Passphrase extends Component<Props, State> {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           onClose={this.stopInfo}
-          width={CONTENT_WIDTH}>
+          verticallyCentered>
           <ViewHeader title={t('passphrase.intro.title')} />
           <ViewContent>
             <MultilineMarkup tagName="p" markup={t('passphrase.intro.message')} />
@@ -151,7 +150,7 @@ class Passphrase extends Component<Props, State> {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           onClose={this.stopInfo}
-          width={CONTENT_WIDTH}>
+          verticallyCentered>
           <ViewHeader title={t('passphrase.what.title')} />
           <ViewContent>
             <MultilineMarkup tagName="p" markup={t('passphrase.what.message')} />
@@ -173,7 +172,7 @@ class Passphrase extends Component<Props, State> {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           onClose={this.stopInfo}
-          width={CONTENT_WIDTH}>
+          verticallyCentered>
           <ViewHeader title={t('passphrase.why.title')} />
           <ViewContent>
             <MultilineMarkup tagName="p" markup={t('passphrase.why.message')} />
@@ -195,7 +194,7 @@ class Passphrase extends Component<Props, State> {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           onClose={this.stopInfo}
-          width={CONTENT_WIDTH}>
+          verticallyCentered>
           <ViewHeader title={t('passphrase.considerations.title')} />
           <ViewContent>
             <MultilineMarkup tagName="p" markup={t('passphrase.considerations.message')} />
@@ -217,7 +216,7 @@ class Passphrase extends Component<Props, State> {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           onClose={this.stopInfo}
-          width={CONTENT_WIDTH}>
+          verticallyCentered>
           <ViewHeader title={t('passphrase.how.title')} />
           <ViewContent>
             <MultilineMarkup tagName="p" markup={t('passphrase.how.message')} />
@@ -239,7 +238,7 @@ class Passphrase extends Component<Props, State> {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           onClose={this.stopInfo}
-          width={CONTENT_WIDTH}>
+          verticallyCentered>
           <ViewHeader title={t('passphrase.summary.title')} />
           <ViewContent>
             <ul>
@@ -281,7 +280,7 @@ class Passphrase extends Component<Props, State> {
         fullscreen
         minHeight={CONTENT_MIN_HEIGHT}
         onClose={this.stopInfo}
-        width={CONTENT_WIDTH}>
+        verticallyCentered>
         <ViewHeader title={t('passphrase.disable')} />
         <ViewContent>
           <MultilineMarkup tagName="p" markup={t('passphrase.disableInfo.message')} />
@@ -317,7 +316,7 @@ class Passphrase extends Component<Props, State> {
             fullscreen
             minHeight={CONTENT_MIN_HEIGHT}
             textCenter
-            width={CONTENT_WIDTH}>
+            verticallyCentered>
             <ViewHeader
               title={t(passphraseEnabled
                 ? 'passphrase.progressDisable.title'
@@ -337,7 +336,7 @@ class Passphrase extends Component<Props, State> {
           <View
             key="progress"
             fullscreen
-            width={CONTENT_WIDTH}>
+            verticallyCentered>
             <ViewHeader
               small
               title={t(passphraseEnabled

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -64,7 +64,10 @@ export const Settings = ({ deviceID }: TProps) => {
       <GuideWrapper>
         <GuidedContent>
           <Header title={<h2>{t('sidebar.device')}</h2>} />
-          <View fullscreen={false} withBottomBar>
+          <View
+            fullscreen={false}
+            verticallyCentered={false}
+            withBottomBar>
             <ViewContent>
               <Grid>
                 <Column>


### PR DESCRIPTION
Trying to make verticallyCentered also work for fullscreen

This still needs more testing and is not ready

- should center all text content in the view (fullscreen and fill should work
- fixes undefined in classname
- fixes paddings with and without sidebar on small, medium and large screen

views to test:

- alertUser: settings -> fullnode -> test with invalid url
- bb02 device settings
- enable passphrase
- address request